### PR TITLE
Remove usage of connectionInfo

### DIFF
--- a/Assets/Scripts/Lobby/LobbyAPIInterface.cs
+++ b/Assets/Scripts/Lobby/LobbyAPIInterface.cs
@@ -85,13 +85,12 @@ namespace LobbyRelaySample.lobby
             AsyncRequestLobby.Instance.DoRequest(task, onComplete);
         }
 
-        public static void UpdatePlayerAsync(string lobbyId, string playerId, Dictionary<string, PlayerDataObject> data, Action<Lobby> onComplete, string allocationId, string connectionInfo)
+        public static void UpdatePlayerAsync(string lobbyId, string playerId, Dictionary<string, PlayerDataObject> data, Action<Lobby> onComplete, string allocationId)
         {
             UpdatePlayerOptions updateOptions = new UpdatePlayerOptions
             {
                 Data = data,
-                AllocationId = allocationId,
-                ConnectionInfo = connectionInfo
+                AllocationId = allocationId
             };
             var task = Lobbies.Instance.UpdatePlayerAsync(lobbyId, playerId, updateOptions);
             AsyncRequestLobby.Instance.DoRequest(task, onComplete);

--- a/Assets/Scripts/Lobby/LobbyAsyncRequests.cs
+++ b/Assets/Scripts/Lobby/LobbyAsyncRequests.cs
@@ -274,18 +274,18 @@ namespace LobbyRelaySample
                 if (result != null)
                     m_lastKnownLobby = result; // Store the most up-to-date lobby now since we have it, instead of waiting for the next heartbeat.
                 onComplete?.Invoke();
-            }, null, null);
+            }, null);
         }
 
         /// <summary>
         /// Lobby can be provided info about Relay (or any other remote allocation) so it can add automatic disconnect handling.
         /// </summary>
-        public void UpdatePlayerRelayInfoAsync(string allocationId, string connectionInfo, Action onComplete)
+        public void UpdatePlayerRelayInfoAsync(string allocationId, Action onComplete)
         {
-            if (!ShouldUpdateData(() => { UpdatePlayerRelayInfoAsync(allocationId, connectionInfo, onComplete); }, onComplete, true)) // Do retry here since the RelayUtpSetup that called this might be destroyed right after this.
+            if (!ShouldUpdateData(() => { UpdatePlayerRelayInfoAsync(allocationId, onComplete); }, onComplete, true)) // Do retry here since the RelayUtpSetup that called this might be destroyed right after this.
                 return;
             string playerId = Locator.Get.Identity.GetSubIdentity(Auth.IIdentityType.Auth).GetContent("id");
-            LobbyAPIInterface.UpdatePlayerAsync(m_lastKnownLobby.Id, playerId, new Dictionary<string, PlayerDataObject>(), (r) => { onComplete?.Invoke(); }, allocationId, connectionInfo);
+            LobbyAPIInterface.UpdatePlayerAsync(m_lastKnownLobby.Id, playerId, new Dictionary<string, PlayerDataObject>(), (r) => { onComplete?.Invoke(); }, allocationId);
         }
 
         /// <param name="data">Key-value pairs, which will overwrite any existing data for these keys. Presumed to be available to all lobby members but not publicly.</param>

--- a/Assets/Scripts/Relay/RelayUtpSetup.cs
+++ b/Assets/Scripts/Relay/RelayUtpSetup.cs
@@ -182,7 +182,7 @@ namespace LobbyRelaySample.relay
                 RelayUtpHost host = gameObject.AddComponent<RelayUtpHost>();
                 host.Initialize(m_networkDriver, m_connections, m_localUser, m_localLobby);
                 m_onJoinComplete(true, host);
-                LobbyAsyncRequests.Instance.UpdatePlayerRelayInfoAsync(m_allocation.AllocationId.ToString(), m_localLobby.RelayCode, null);
+                LobbyAsyncRequests.Instance.UpdatePlayerRelayInfoAsync(m_allocation.AllocationId.ToString(), null);
             }
         }
     }
@@ -245,7 +245,7 @@ namespace LobbyRelaySample.relay
                 RelayUtpClient client = gameObject.AddComponent<RelayUtpClient>();
                 client.Initialize(m_networkDriver, m_connections, m_localUser, m_localLobby);
                 m_onJoinComplete(true, client);
-                LobbyAsyncRequests.Instance.UpdatePlayerRelayInfoAsync(m_allocation.AllocationId.ToString(), m_localLobby.RelayCode, null);
+                LobbyAsyncRequests.Instance.UpdatePlayerRelayInfoAsync(m_allocation.AllocationId.ToString(), null);
             }
         }
     }


### PR DESCRIPTION
The Lobby service recently deprecated the `connectionInfo` property that is attached to players. This PR removes references to that property in order to maintain consistency with the Lobby API spec.